### PR TITLE
rangeの記述を簡略化

### DIFF
--- a/ch3/face/rotate-test.py
+++ b/ch3/face/rotate-test.py
@@ -18,7 +18,7 @@ def face_detect(img):
         cv2.rectangle(img, (x, y), (x+w, y+h), red, thickness=30)
 
 # 角度毎に検証する
-for i in range(0, 9):
+for i in range(9):
     ang = i * 10
     print("---" + str(ang) + "---")
     img_r = ndimage.rotate(img, ang)


### PR DESCRIPTION
`range(0, 9)`と`range(9)`は等価であり、後者に変えても可読性が大きく落ちることはないと考えられるため、後者に変更しました。